### PR TITLE
Fix/linux env/readlink

### DIFF
--- a/miasm/os_dep/linux/environment.py
+++ b/miasm/os_dep/linux/environment.py
@@ -292,7 +292,6 @@ class FileSystem(object):
             path = path.lstrip(path_sep)
             out_path = os.path.join(base_path, path)
 
-        assert out_path.startswith(base_path + path_sep)
 
         if os.path.islink(out_path):
             link_target = os.readlink(out_path)
@@ -302,6 +301,8 @@ class FileSystem(object):
                 out_path = self.resolve_path(link)
             else:
                 out_path = link
+
+        assert out_path.startswith(base_path + path_sep)
 
         log.debug("-> {!r}".format(out_path))
 

--- a/miasm/os_dep/linux/syscall.py
+++ b/miasm/os_dep/linux/syscall.py
@@ -707,7 +707,7 @@ def sys_x86_64_readlink(jitter, linux_env):
         # Not a link
         jitter.cpu.RAX = -1
     else:
-        data = link[:bufsize - 1] + b"\x00"
+        data = link[:bufsize - 1].encode() + b"\x00"
         jitter.vm.set_mem(buf, data)
         jitter.cpu.RAX = len(data) - 1
 


### PR DESCRIPTION
Fix sandbox escape.

# case 1
My architecture: 
```
file_sb/
├── home
│   └── user
│       └── bin.elf
└── proc
    ├── 1000
    │   └── exe -> ../../home/user/bin.elf
    └── self -> 1000
```

``FileSystem::resolve_path`` returns non-sandboxed path if ``path`` parameter is a symbolic link and ``follow_link`` is False. See below:

 ```
[syscalls][sys_x86_64_readlink][DEBUG]: sys_readlink('/proc/self/exe', 13f028, fff)
[environment][resolve_path][DEBUG]: resolve_path(path='/proc/self/exe', follow_link=False)
[environment][resolve_path][DEBUG]: -> 'home/user/bin.elf'
[syscalls][syscall_x86_64_exception_handler][DEBUG]: -> ffffffffffffffff
```

# case 2
```
file_sb/
├── home
│   └── user
│       └── bin.elf
└── proc
    ├── 1000
    │   └── exe -> ../../../../home/user/bin.elf
    └── self -> 1000
```

Second case:

```
[syscalls][sys_generic_open][DEBUG]: sys_open('/proc/self/exe', 0, 0)
[environment][resolve_path][DEBUG]: resolve_path(path='/proc/self/exe', follow_link=True)
[environment][resolve_path][DEBUG]: resolve_path(path='../../home/user/bin.elf', follow_link=True)
[environment][resolve_path][DEBUG]: -> '/home/bla/[TRUNCATED]/file_sb/../../home/user/bin.elf'
[environment][resolve_path][DEBUG]: -> '/home/bla/[TRUNCATED]/file_sb/../../home/user/bin.elf'
[syscalls][syscall_x86_64_exception_handler][DEBUG]: -> ffffffffffffffff

...

[syscalls][sys_x86_64_readlink][DEBUG]: sys_readlink('/proc/self/exe', 13f028, fff)
[environment][resolve_path][DEBUG]: resolve_path(path='/proc/self/exe', follow_link=False)
[environment][resolve_path][DEBUG]: -> '../../home/user/bin.elf'
[syscalls][syscall_x86_64_exception_handler][DEBUG]: -> ffffffffffffffff
```

# Current behavior
## try to solve relative link targeting something in the sandbox
```
[environment][readlink][DEBUG]: readlink('/proc/self/exe')
[environment][resolve_path][DEBUG]: resolve_path(path='/proc/self/exe', follow_link=False)
[environment][resolve_path][DEBUG]: -> '/home/bla/[TRUNCATED]/file_sb/proc/self/exe'
[environment][resolve_path][DEBUG]: resolve_path(path='/home/bla/[TRUNCATED]/file_sb/home/user/bin.elf', follow_link=False)
[environment][resolve_path][DEBUG]: -> '/home/bla/[TRUNCATED]/file_sb/home/user/bin.elf'
[environment][readlink][DEBUG]: -> '/home/bla/[TRUNCATED]/file_sb/home/user/bin.elf'
[syscalls][syscall_x86_64_exception_handler][DEBUG]: -> 4b
````

## try to solve relative link targeting something out of sandbox
```
[environment][readlink][DEBUG]: readlink('/proc/self/exe')
[environment][resolve_path][DEBUG]: resolve_path(path='/proc/self/exe', follow_link=False)
[environment][resolve_path][DEBUG]: -> '/home/bla/[TRUNCATED]/file_sb/proc/self/exe'
[environment][resolve_path][DEBUG]: resolve_path(path='/home/bla/[TRUNCATED]/bin.elf', follow_link=False)
[environment][resolve_path][DEBUG]: -> '/home/bla/[TRUNCATED]/file_sb/home/bla/[TRUNCATED]/chal/home/user/bin.elf'
[environment][readlink][DEBUG]: -> '/home/bla/[TRUNCATED]/file_sb/home/bla/[TRUNCATED]/chal/home/user/bin.elf'
```

## try to solve absolute link targeting something in the sandbox
```
[environment][readlink][DEBUG]: readlink('/proc/self/exe')
[environment][resolve_path][DEBUG]: resolve_path(path='/proc/self/exe', follow_link=False)
[environment][resolve_path][DEBUG]: -> '/home/bla/[TRUNCATED]/file_sb/proc/self/exe'
[environment][resolve_path][DEBUG]: resolve_path(path='/home/bla/[TRUNCATED]/file_sb/home/user/bin.elf', follow_link=False)
[environment][resolve_path][DEBUG]: -> '/home/bla/[TRUNCATED]/file_sb/home/user/bin.elf'
[environment][readlink][DEBUG]: -> '/home/bla/[TRUNCATED]/file_sb/home/user/bin.elf'
```

## try to solve absolute link targting something out of the sandbox
```
[syscalls][sys_generic_open][DEBUG]: sys_open('/proc/self/exe', 0, 0)
[environment][resolve_path][DEBUG]: resolve_path(path='/proc/self/exe', follow_link=True)
[environment][readlink][DEBUG]: readlink('/home/bla/[TRUNCATED]/file_sb/proc/self/exe')
[environment][resolve_path][DEBUG]: resolve_path(path='/home/bla/[TRUNCATED]/file_sb/proc/self/exe', follow_link=False)
[environment][resolve_path][DEBUG]: -> '/home/bla/[TRUNCATED]/file_sb/proc/self/exe'
[environment][resolve_path][DEBUG]: resolve_path(path='/tmp', follow_link=False)
[environment][resolve_path][DEBUG]: -> '/home/bla/[TRUNCATED]/file_sb/tmp'
[environment][readlink][DEBUG]: -> '/home/bla/[TRUNCATED]/file_sb/tmp'
[environment][resolve_path][DEBUG]: resolve_path(path='/home/bla/[TRUNCATED]/file_sb/tmp', follow_link=True)
[environment][resolve_path][DEBUG]: -> '/home/bla/[TRUNCATED]/file_sb/tmp'
[environment][resolve_path][DEBUG]: -> '/home/bla/[TRUNCATED]/file_sb/tmp'
[syscalls][syscall_x86_64_exception_handler][DEBUG]: -> ffffffffffffffff
```